### PR TITLE
fix: remove broken funding file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: [DEVs-Dungeon](https://github.com/Neklaustares-tPtwP)


### PR DESCRIPTION
Things added/changed:

- Remove broken funding file.
  - The provided link was pointing to an invalid link (invalid GitHub link and no sponsors profile). Removing the whole file will prevent a broken sponsor button.
  If you have another valid link, feel free to let me know and I'll update it in this PR. Thanks. 🙂
